### PR TITLE
expose calculated_flow_set

### DIFF
--- a/comfortzone_decoder_status.cpp
+++ b/comfortzone_decoder_status.cpp
@@ -2019,6 +2019,7 @@ void czdec::reply_r_status_v180_x40(comfortzone_heatpump *czhp, KNOWN_REGISTER *
 	R_REPLY_STATUS_V180_STATUS_x40 *q = (R_REPLY_STATUS_V180_STATUS_x40 *)p;
 
 	czhp->comfortzone_status.room_heating_setting = get_uint16(q->heating_calculated_setting);
+	czhp->comfortzone_status.calculated_flow_set = get_uint16(q->calculated_flow_set);
 
 #ifdef DEBUG
 	int reg_v;

--- a/comfortzone_status.h
+++ b/comfortzone_status.h
@@ -121,6 +121,8 @@ typedef struct
 	// current heatpump calculated setting
 	Subscribable<uint16_t> fan_speed_duty;					// %, * 10 (proto: 1.60, 1.80)
 	Subscribable<int16_t> hot_water_calculated_setting;	// °C, * 10 (heatpump selected). can be hot_water_setting (no extra hot water) or a different value (proto: 1.60, 1.80)
+
+	Subscribable<int16_t> calculated_flow_set;	// °C, * 10 (heatpump selected) (proto: 1.80)
 } COMFORTZONE_STATUS;
 
 #endif


### PR DESCRIPTION
This one seems to report correct values, so it might make sense to expose to the `COMFORTZONE_STATUS` level