### PR TITLE
allow to control fireplace mode

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -189,6 +189,12 @@ comfortzone_heatpump object.
  Possible temperature offset goes from -10.0° to 10.0°, with step of 0.1°
 
 
+ * bool set_fireplace_mode(bool enable, int timeout = 5);
+
+ Enable/disable temporary mode to start the fireplace
+ (disables fan for 5 minutes, runs completely on electricity during that period)
+
+
  Special methods
  ---------------
 

--- a/comfortzone_crafting.h
+++ b/comfortzone_crafting.h
@@ -33,6 +33,8 @@ class czcraft
 		KR_TEMP_OFFSET_SENSOR5,	// set sensor 5 temperature offset, parameter => -100 (=-10°) to 100 (=10.0°)
 		KR_TEMP_OFFSET_SENSOR6,	// set sensor 6 temperature offset, parameter => -100 (=-10°) to 100 (=10.0°)
 		KR_TEMP_OFFSET_SENSOR7,	// set sensor 7 temperature offset, parameter => -100 (=-10°) to 100 (=10.0°)
+		KR_FIREPLACE_MODE_ENABLE, // enable temporary mode to start the fireplace (disables fan for 5 minutes, runs completely on electricity during that period)
+		KR_FIREPLACE_MODE_DISABLE, // disable temporary fireplace mode (shouldn't be needed normally as it is called automatically by heatpump after 5 minutes)
 	} KNOWN_REGISTER_CRAFT_NAME;
 
 	// craft a W_CMD packet

--- a/comfortzone_decoder.cpp
+++ b/comfortzone_decoder.cpp
@@ -108,6 +108,14 @@ static czdec::KNOWN_REGISTER kr_decoder[] =
 		{ {0x01, 0x02, 0x03, 0x04, 0x0B, 0x09, 0x00, 0x0D, 0x04}, czcraft::KR_UNCRAFTABLE, "Hot water extra time", czdec::cmd_r_generic, czdec::cmd_w_time_minutes, czdec::reply_r_time_minutes, czdec::reply_w_generic},
 
 
+// Write: 01 02 03 04 0b 09 81 13 00 00 04 ab
+// Write reply: 01 02 03 04 0b 09 81 13 00 04 f9
+		{ {0x01, 0x02, 0x03, 0x04, 0x0B, 0x09, 0x81, 0x13, 0x00}, czcraft::KR_FIREPLACE_MODE_ENABLE, "Enable fireplace mode", czdec::empty, czdec::cmd_w_generic_2byte, czdec::empty, czdec::reply_w_generic},
+
+// Write: 01 02 03 04 0b 09 41 13 00 ff fb 3d
+// Write reply: 01 02 03 04 0b 09 41 13 00 08 63
+		{ {0x01, 0x02, 0x03, 0x04, 0x0B, 0x09, 0x41, 0x13, 0x00}, czcraft::KR_FIREPLACE_MODE_DISABLE, "Disable fireplace mode", czdec::empty, czdec::cmd_w_generic_2byte, czdec::empty, czdec::reply_w_generic},
+
 
 		/* @OK */ { {0x01, 0x02, 0x03, 0x04, 0x0B, 0x09, 0x00, 0x0E, 0x00}, czcraft::KR_UNCRAFTABLE, "Sanitary priority (get)", czdec::cmd_r_generic, czdec::empty, czdec::reply_r_sanitary_priority, czdec::empty},
 

--- a/comfortzone_heatpump.cpp
+++ b/comfortzone_heatpump.cpp
@@ -566,6 +566,43 @@ bool comfortzone_heatpump::set_extra_hot_water(bool enable, int timeout)
 }
 
 // true = enable, false = disable
+bool comfortzone_heatpump::set_fireplace_mode(bool enable, int timeout)
+{
+	W_CMD cmd;
+	W_REPLY expected_reply;
+	czdec::KNOWN_REGISTER *kr;
+	uint16_t cmd_value;
+	byte reply_value;
+	bool push_result;
+
+	// Don't know why this setting requires 2 register (???)
+	if(enable)
+	{
+		kr = czdec::kr_craft_name_to_index(czcraft::KR_FIREPLACE_MODE_ENABLE);
+		cmd_value = 0x0400;
+		reply_value = 0x04;
+	}
+	else
+	{
+		kr = czdec::kr_craft_name_to_index(czcraft::KR_FIREPLACE_MODE_DISABLE);
+		cmd_value = 0xFBFF;
+		reply_value = 0x08;
+	}
+
+	if(kr == NULL)
+	{
+		RETURN_MESSAGE("nczcraft::KR_FIREPLACE_MODE_* Not found");
+		return false;
+	}
+
+	czcraft::craft_w_cmd(this, &cmd, kr->reg_num, cmd_value);
+	czcraft::craft_w_reply(this, &expected_reply, kr->reg_num, reply_value);
+
+	push_result = push_settings((byte*)&cmd, sizeof(cmd), (byte*)&expected_reply, sizeof(expected_reply), timeout, true);
+	return push_result;
+}
+
+// true = enable, false = disable
 bool comfortzone_heatpump::set_automatic_daylight_saving(bool enable, int timeout)
 {
 	W_CMD cmd;

--- a/comfortzone_heatpump.h
+++ b/comfortzone_heatpump.h
@@ -76,6 +76,8 @@ class comfortzone_heatpump
 	bool set_extra_hot_water(bool enable, int timeout = 5);	// true = enable, false = disable
 	bool set_automatic_daylight_saving(bool enable, int timeout = 5);	// true = enable, false = disable
 
+	bool set_fireplace_mode(bool enable, int timeout = 5); // true = enable, false = disable
+
 	bool set_sensor_offset(uint16_t sensor_num, float temp_offset, int timeout = 5);	// sensor: [0:7], offset in °C (-10.0° -> 10.0°)
 
 	// when debug mode is enabled, functions may return messages

--- a/library.json
+++ b/library.json
@@ -15,5 +15,5 @@
       "type": "git",
       "url": "https://github.com/qix67/comfortzone_heatpump"
   },
-  "version": "1.1"
+  "version": "1.2"
 }


### PR DESCRIPTION
There is a setting in Comfortzone EX50 that allows to temporarily enable "fireplace mode", which essentially disables the fan to allow to ignite fire in the fireplace without the negative air pressure in the house sucking out flames out. 
The heatpump automatically enables the fan after approximately 5 minutes.

I've found the appropriate register to control this setting.