### PR TITLE
Add a sensor for general alarm

### DIFF
--- a/comfortzone_decoder_status.cpp
+++ b/comfortzone_decoder_status.cpp
@@ -378,7 +378,10 @@ void czdec::reply_r_status_02(comfortzone_heatpump *czhp, KNOWN_REGISTER *kr, R_
 
 	active_alarm = get_uint16(q->pending_alarm) ^ get_uint16(q->acknowledged_alarm);
 
-	czhp->comfortzone_status.filter_alarm = (active_alarm & 0x0002) ? true : false ;
+	czhp->comfortzone_status.filter_alarm = (active_alarm & 0x0002) ? true : false;
+
+	// any alarm other than filter alarm
+	czhp->comfortzone_status.general_alarm = (active_alarm & ~0x0002) ? true : false;
 
 	czhp->comfortzone_status.hour = q->hour1;
 	czhp->comfortzone_status.minute = q->minute1;

--- a/comfortzone_status.h
+++ b/comfortzone_status.h
@@ -61,6 +61,7 @@ typedef struct
 	Subscribable<uint16_t> fan_time_to_filter_change;		// days (proto: 1.60, 1.80, 2.21)
 
 	Subscribable<bool> filter_alarm;								// true = replace/clean filter alarm, false = filter ok (proto: 1.60, 1.80)
+	Subscribable<bool> general_alarm;								// true = any active alarm (excluding filter), false = no alarm (proto: 1.60, 1.80)
 
 	Subscribable<bool> hot_water_production;					// true = on, false = off
 	Subscribable<bool> room_heating_in_progress;				// true = on, false = off


### PR DESCRIPTION
Can be useful to set alerts on alarms other than the one related to filter replacement